### PR TITLE
feat: gamification data in adaptive testing

### DIFF
--- a/core/queries/question_queries.py
+++ b/core/queries/question_queries.py
@@ -100,6 +100,7 @@ def get_next_question_bundle(
             None,
             determine_continue_actions(user, subtopic),
             determine_suggested_actions(user, subtopic),
+            build_gamification_data(user, subtopic, None),
         )
 
     options = list(QuestionOption.objects.filter(question=next_question))
@@ -110,6 +111,7 @@ def get_next_question_bundle(
         QuestionBundle(question=next_question, options=options, saved_for_later=saved_for_later),
         [],
         determine_suggested_actions(user, subtopic),
+        build_gamification_data(user, subtopic, next_question),
     )
 
 
@@ -360,7 +362,67 @@ def increment_view_count(user, question):
     metrics.save()
 
 
-def getQuestionResponse(question_bundle, continue_actions, suggested_actions):
+def _get_ability_label(difficulty_delta: float) -> str:
+    if difficulty_delta > 1.0:
+        return "MUCH_HARDER"
+    elif difficulty_delta > 0.25:
+        return "HARDER"
+    elif difficulty_delta >= -0.25:
+        return "ON_TARGET"
+    elif difficulty_delta >= -1.0:
+        return "EASIER"
+    return "MUCH_EASIER"
+
+
+def build_gamification_data(
+    user: MacFastUser, subtopic: UnitSubtopic, question: Question | None
+) -> dict:
+    user_ability, _ = UserTopicAbilityScore.objects.get_or_create(
+        user=user, unit_sub_topic=subtopic
+    )
+    test_session, _ = TestSession.objects.get_or_create(user=user, subtopic=subtopic)
+
+    ability_score = float(user_ability.score)
+    ability_variance = float(user_ability.variance)
+
+    recent_correct = (
+        QuestionAttempt.objects.filter(
+            user=user,
+            question__subtopic=subtopic,
+            skipped=False,
+        )
+        .order_by("-timestamp")
+        .values_list("answered_correctly", flat=True)[:20] # only check the last 20 questions
+    )
+    streak = 0
+    for correct in recent_correct:
+        if correct:
+            streak += 1
+        else:
+            break
+
+    gamification: dict = {
+        "user_ability": round(ability_score, 4),
+        "ability_variance": round(ability_variance, 4),
+        "questions_answered": test_session.questions_answered_count,
+        "current_streak": streak,
+    }
+
+    if question is not None:
+        question_difficulty = float(question.difficulty)
+        difficulty_delta = round(question_difficulty - ability_score, 4)
+        gamification.update(
+            {
+                "question_difficulty": question_difficulty,
+                "difficulty_delta": difficulty_delta,
+                "difficulty_label": _get_ability_label(difficulty_delta),
+            }
+        )
+
+    return gamification
+
+
+def getQuestionResponse(question_bundle, continue_actions, suggested_actions, gamification=None):
     return Response(
         {
             "question": (
@@ -370,6 +432,7 @@ def getQuestionResponse(question_bundle, continue_actions, suggested_actions):
             ),
             "continue_actions": [action.value for action in continue_actions],
             "suggested_actions": [action.value for action in suggested_actions],
+            "gamification": gamification or {},
         },
         status=status.HTTP_200_OK,
     )

--- a/core/views/adaptive_test/next_test_question.py
+++ b/core/views/adaptive_test/next_test_question.py
@@ -32,5 +32,5 @@ class NextTestQuestionView(APIView):
             unit__name=unit_name,
             name=subtopic_name,
         )
-        question_bundle, continue_actions, suggested_actions = get_next_question_bundle(user, subtopic)
-        return getQuestionResponse(question_bundle, continue_actions, suggested_actions)
+        question_bundle, continue_actions, suggested_actions, gamification = get_next_question_bundle(user, subtopic)
+        return getQuestionResponse(question_bundle, continue_actions, suggested_actions, gamification)

--- a/core/views/adaptive_test/skip_test_question.py
+++ b/core/views/adaptive_test/skip_test_question.py
@@ -26,5 +26,5 @@ class SkipTestQuestionView(views.APIView):
                 {"error": "Question has been skipped too many times."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        question_bundle, continue_actions, suggested_actions = get_next_question_bundle(request.user, question.subtopic)
-        return getQuestionResponse(question_bundle, continue_actions, suggested_actions)
+        question_bundle, continue_actions, suggested_actions, gamification = get_next_question_bundle(request.user, question.subtopic)
+        return getQuestionResponse(question_bundle, continue_actions, suggested_actions, gamification)


### PR DESCRIPTION
* Added build_gamification_data function to calculate user ability and question difficulty metrics.
* Updated get_next_question_bundle to include gamification data in responses.
* Modified getQuestionResponse to return gamification information.
* Updated API views for next test question and skip test question to handle new gamification data.

used in https://github.com/McMaster-FAST/frontend/pull/73

POST /api/core/adaptive-test/next-question/ now returns:

```
{
    "question": {
        "public_id": "0cbfbfe4-422b-47e7-a3a1-10c294807e19",
        "content": "<p>Which of the following is the <strong>strongest acid</strong>? ....",
        "options": [
            {
                "public_id": "8de66b8b-6463-417d-9b8d-80c3eed29870",
                "content": "iv"
            },
            {
                "public_id": "ecb33901-d83f-4403-90b9-dd2288830ac8",
                "content": "iii"
            },
            {
                "public_id": "017ae565-4a01-4b30-b75b-54d6996be523",
                "content": "ii"
            },
            {
                "public_id": "cd978533-3066-4290-84c5-eb202146dd93",
                "content": "i"
            }
        ],
        "saved_for_later": false
    },
    "continue_actions": [],
    "suggested_actions": [],
    "gamification": {
        "user_ability": 1.2662,
        "ability_variance": 0.305,
        "questions_answered": 0,
        "current_streak": 1,
        "question_difficulty": 1.901,
        "difficulty_delta": 0.6348,
        "difficulty_label": "HARDER"
    }
}
```