### PR TITLE
Add option explanations and course question progress metrics

### DIFF
--- a/core/serializers/instructor_question_serializer.py
+++ b/core/serializers/instructor_question_serializer.py
@@ -20,6 +20,9 @@ class QuestionSerializer(serializers.ModelSerializer):
     )
 
     subtopic_name = serializers.CharField(source="subtopic.name", read_only=True)
+    subtopic_public_id = serializers.UUIDField(source="subtopic.public_id", read_only=True)
+    unit_public_id = serializers.UUIDField(source="subtopic.unit.public_id", read_only=True)
+    unit_name = serializers.CharField(source="subtopic.unit.name", read_only=True)
     saved_for_later = serializers.SerializerMethodField()
 
     def get_saved_for_later(self, obj):
@@ -44,7 +47,10 @@ class QuestionSerializer(serializers.ModelSerializer):
             "images",  # The images attached to the question
             "options",  # The multiple choice answers
             "subtopic",  # For assigning question to subtopic on creation
+            "subtopic_public_id",
             "subtopic_name",
+            "unit_public_id",
+            "unit_name",
             "saved_for_later",
         ]
         read_only_fields = ["public_id", "selection_frequency"]

--- a/core/serializers/question_option_serializer.py
+++ b/core/serializers/question_option_serializer.py
@@ -11,6 +11,7 @@ class QuestionOptionSerializer(serializers.ModelSerializer):
         fields = [
             'public_id',
             'content',
+            'explanation',
             'is_answer',
             'selection_frequency',
         ]
@@ -25,6 +26,7 @@ class QuestionOptionCRUDSerializer(serializers.ModelSerializer):
         fields = [
             'public_id',
             'content',
+            'explanation',
             'is_answer',
             'selection_frequency',
             'images',

--- a/core/tests/test_course_detail_metrics.py
+++ b/core/tests/test_course_detail_metrics.py
@@ -1,0 +1,115 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analytics.models import QuestionAttempt
+from core.models import Question
+from courses.models import Course
+from courses.models import Unit
+from courses.models import UnitSubtopic
+from sso_auth.models import MacFastUser
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_attempt(
+    user: MacFastUser,
+    question: Question,
+    *,
+    answered_correctly: bool,
+    skipped: bool = False,
+) -> QuestionAttempt:
+    return QuestionAttempt.objects.create(
+        user=user,
+        question=question,
+        answered_correctly=answered_correctly,
+        skipped=skipped,
+        updated_ability_score=0,
+        time_spent=1.0,
+    )
+
+
+def test_course_detail_includes_unit_progress(
+    api_client: APIClient,
+    user: MacFastUser,
+    course: Course,
+    unit: Unit,
+    subtopic: UnitSubtopic,
+    question: Question,
+) -> None:
+    user.is_staff = True
+    user.save(update_fields=['is_staff'])
+
+    second_question = Question.objects.create(
+        subtopic=subtopic,
+        serial_number='Q002',
+        content='What is 3 + 3?',
+    )
+    inactive_question = Question.objects.create(
+        subtopic=subtopic,
+        serial_number='Q003',
+        content='Inactive question',
+        is_active=False,
+    )
+    other_unit = Unit.objects.create(course=course, name='Other Unit', number=2)
+    other_subtopic = UnitSubtopic.objects.create(unit=other_unit, name='Other Subtopic')
+    other_unit_question = Question.objects.create(
+        subtopic=other_subtopic,
+        serial_number='Q004',
+        content='Other unit question',
+    )
+
+    _create_attempt(user, question, answered_correctly=True)
+    _create_attempt(user, question, answered_correctly=True)
+    _create_attempt(user, second_question, answered_correctly=False)
+    _create_attempt(user, second_question, answered_correctly=True, skipped=True)
+    _create_attempt(user, inactive_question, answered_correctly=True)
+    _create_attempt(user, other_unit_question, answered_correctly=True)
+
+    response = api_client.get(f'/api/courses/{course.code}/')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    unit_data = response.data['units'][0]
+    assert unit_data['public_id'] == str(unit.public_id)
+    assert unit_data['correct_questions'] == 1
+    assert unit_data['total_questions'] == 2
+    assert unit_data['completion_percentage'] == 50.0
+
+
+def test_course_list_includes_course_progress(
+    api_client: APIClient,
+    user: MacFastUser,
+    course: Course,
+    unit: Unit,
+    subtopic: UnitSubtopic,
+    question: Question,
+) -> None:
+    user.is_staff = True
+    user.save(update_fields=['is_staff'])
+
+    second_question = Question.objects.create(
+        subtopic=subtopic,
+        serial_number='Q100',
+        content='Another active question',
+    )
+    Question.objects.create(
+        subtopic=subtopic,
+        serial_number='Q101',
+        content='Inactive question',
+        is_active=False,
+    )
+
+    _create_attempt(user, question, answered_correctly=True)
+    _create_attempt(user, second_question, answered_correctly=False)
+    _create_attempt(user, second_question, answered_correctly=True, skipped=True)
+
+    response = api_client.get('/api/courses/')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 1
+
+    course_data = response.data[0]
+    assert course_data['public_id'] == str(course.public_id)
+    assert course_data['correct_questions'] == 1
+    assert course_data['total_questions'] == 2

--- a/core/tests/test_option_viewset.py
+++ b/core/tests/test_option_viewset.py
@@ -61,11 +61,16 @@ class TestCreateOption:
         api_client: APIClient,
         question: Question,
     ) -> None:
-        data = {'content': 'Option A', 'is_answer': False}
+        data = {
+            'content': 'Option A',
+            'explanation': 'Option A explanation',
+            'is_answer': False,
+        }
         response = api_client.post(_options_url(question), data)
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['content'] == 'Option A'
+        assert response.data['explanation'] == 'Option A explanation'
         assert response.data['is_answer'] is False
         assert 'public_id' in response.data
 
@@ -152,6 +157,7 @@ class TestRetrieveOption:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['public_id'] == str(question_option.public_id)
         assert response.data['content'] == '4'
+        assert 'explanation' in response.data
         assert response.data['is_answer'] is True
         assert 'selection_frequency' in response.data
         assert 'images' in response.data
@@ -176,7 +182,11 @@ class TestUpdateOption:
         question: Question,
         question_option: QuestionOption,
     ) -> None:
-        data = {'content': 'Updated content', 'is_answer': False}
+        data = {
+            'content': 'Updated content',
+            'explanation': 'Updated explanation',
+            'is_answer': False,
+        }
         response = api_client.put(
             _option_detail_url(question, question_option),
             data,
@@ -184,6 +194,7 @@ class TestUpdateOption:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['content'] == 'Updated content'
+        assert response.data['explanation'] == 'Updated explanation'
         assert response.data['is_answer'] is False
 
     def test_partial_update_returns_200(
@@ -201,6 +212,21 @@ class TestUpdateOption:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['content'] == 'Partially updated'
         assert response.data['is_answer'] is True
+
+    def test_partial_update_explanation_returns_200(
+        self,
+        api_client: APIClient,
+        question: Question,
+        question_option: QuestionOption,
+    ) -> None:
+        data = {'explanation': 'Partially updated explanation'}
+        response = api_client.patch(
+            _option_detail_url(question, question_option),
+            data,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['explanation'] == 'Partially updated explanation'
 
 
 class TestDeleteOption:

--- a/core/views/question_viewset.py
+++ b/core/views/question_viewset.py
@@ -3,6 +3,7 @@ from rest_framework import viewsets, filters
 from rest_framework.permissions import IsAuthenticated
 
 from django_filters.rest_framework import DjangoFilterBackend
+from django.shortcuts import get_object_or_404
 
 from ..models import Question
 from ..serializers import QuestionSerializer
@@ -34,12 +35,15 @@ class QuestionViewSet(viewsets.ModelViewSet):
     # 20 is a good size
     pagination_class.page_size = 20
 
+    def _get_subtopic_public_id(self):
+        return self.kwargs.get("subtopic_public_id") or self.kwargs.get("subtopic_pk")
+
     def get_queryset(self):
         queryset = Question.objects.all().order_by("id")
 
-        subtopic_pk = self.kwargs.get("subtopic_pk")
-        if subtopic_pk:
-            queryset = queryset.filter(subtopic_id=subtopic_pk)
+        subtopic_public_id = self._get_subtopic_public_id()
+        if subtopic_public_id:
+            queryset = queryset.filter(subtopic__public_id=subtopic_public_id)
 
         course_code = self.kwargs.get("course_code")
         if course_code:
@@ -48,10 +52,10 @@ class QuestionViewSet(viewsets.ModelViewSet):
         return queryset
 
     def perform_create(self, serializer):
-        subtopic_pk = self.kwargs.get("subtopic_pk")
+        subtopic_public_id = self._get_subtopic_public_id()
 
-        if subtopic_pk:
-            subtopic = UnitSubtopic.objects.get(pk=subtopic_pk)
+        if subtopic_public_id:
+            subtopic = get_object_or_404(UnitSubtopic, public_id=subtopic_public_id)
             serializer.save(subtopic=subtopic)
         else:
             serializer.save()

--- a/courses/serializers/course_serializer.py
+++ b/courses/serializers/course_serializer.py
@@ -1,4 +1,6 @@
 from core.models import CourseResumeState
+from analytics.models import QuestionAttempt
+from core.models import Question
 from core.serializers.resume_serializer import ResumeTargetSerializer
 from courses.serializers.subtopic_serializer import UnitSubtopicSerializer
 from rest_framework import serializers
@@ -7,6 +9,8 @@ from courses.models import Course
 
 class CourseSerializer(serializers.ModelSerializer):
     resume_target = serializers.SerializerMethodField()
+    correct_questions = serializers.SerializerMethodField()
+    total_questions = serializers.SerializerMethodField()
 
     def get_resume_target(self, obj):
         resume_state = CourseResumeState.objects.filter(
@@ -21,6 +25,29 @@ class CourseSerializer(serializers.ModelSerializer):
                 }
             ).data
         return None
+
+    def get_correct_questions(self, obj):
+        request = self.context.get("request")
+        if not request:
+            return 0
+        return (
+            QuestionAttempt.objects.filter(
+                user=request.user,
+                question__subtopic__unit__course=obj,
+                question__is_active=True,
+                answered_correctly=True,
+                skipped=False,
+            )
+            .values("question_id")
+            .distinct()
+            .count()
+        )
+
+    def get_total_questions(self, obj):
+        return Question.objects.filter(
+            subtopic__unit__course=obj,
+            is_active=True,
+        ).count()
 
     class Meta:
         model = Course

--- a/courses/serializers/unit_subtopic_serializer.py
+++ b/courses/serializers/unit_subtopic_serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from analytics.models import QuestionAttempt
+from core.models import Question
 from .subtopic_serializer import UnitSubtopicSerializer
 from courses.models import Unit
 
@@ -10,7 +12,59 @@ class UnitDetailSerializer(serializers.ModelSerializer):
     subtopics = UnitSubtopicSerializer(
         many=True, read_only=True, source="unitsubtopic_set"
     )
+    correct_questions = serializers.SerializerMethodField()
+    total_questions = serializers.SerializerMethodField()
+    completion_percentage = serializers.SerializerMethodField()
 
     class Meta:
         model = Unit
-        fields = ["public_id", "number", "name", "description", "course", "subtopics"]
+        fields = [
+            "public_id",
+            "number",
+            "name",
+            "description",
+            "course",
+            "correct_questions",
+            "total_questions",
+            "completion_percentage",
+            "subtopics",
+        ]
+
+    def get_correct_questions(self, obj):
+        request = self.context.get("request")
+        if not request:
+            return 0
+
+        return (
+            QuestionAttempt.objects.filter(
+                user=request.user,
+                question__subtopic__unit=obj,
+                question__is_active=True,
+                answered_correctly=True,
+                skipped=False,
+            )
+            .values("question_id")
+            .distinct()
+            .count()
+        )
+
+    def get_total_questions(self, obj):
+        prefetched_subtopics = getattr(obj, "_prefetched_objects_cache", {}).get(
+            "unitsubtopic_set"
+        )
+        if prefetched_subtopics is not None:
+            return sum(
+                subtopic.question_count
+                if hasattr(subtopic, "question_count")
+                else subtopic.question_set.filter(is_active=True).count()
+                for subtopic in prefetched_subtopics
+            )
+
+        return Question.objects.filter(subtopic__unit=obj, is_active=True).count()
+
+    def get_completion_percentage(self, obj):
+        total_questions = self.get_total_questions(obj)
+        if not total_questions:
+            return 0.0
+
+        return round((self.get_correct_questions(obj) / total_questions) * 100, 2)

--- a/courses/views/studyaid_viewset.py
+++ b/courses/views/studyaid_viewset.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from courses.models import StudyAid, UnitSubtopic
@@ -7,22 +8,26 @@ from courses.serializers import StudyAidSerializer
 class StudyAidViewSet(viewsets.ModelViewSet):
     serializer_class = StudyAidSerializer
     permission_classes = [IsAuthenticated]
+    lookup_field = "public_id"
+
+    def _get_subtopic_public_id(self):
+        return self.kwargs.get("subtopic_public_id") or self.kwargs.get("subtopic_pk")
 
     def get_queryset(self):
         queryset = StudyAid.objects.all()
 
-        subtopic_pk = self.kwargs.get("subtopic_pk")
+        subtopic_public_id = self._get_subtopic_public_id()
 
-        if subtopic_pk:
-            queryset = queryset.filter(subtopic_id=subtopic_pk)
+        if subtopic_public_id:
+            queryset = queryset.filter(subtopic__public_id=subtopic_public_id)
 
         return queryset
 
     def perform_create(self, serializer):
-        subtopic_pk = self.kwargs.get("subtopic_pk")
+        subtopic_public_id = self._get_subtopic_public_id()
 
-        if subtopic_pk:
-            subtopic = UnitSubtopic.objects.get(pk=subtopic_pk)
+        if subtopic_public_id:
+            subtopic = get_object_or_404(UnitSubtopic, public_id=subtopic_public_id)
             serializer.save(subtopic=subtopic)
         else:
             serializer.save()

--- a/courses/views/subtopic_viewset.py
+++ b/courses/views/subtopic_viewset.py
@@ -1,3 +1,5 @@
+
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from courses.models import UnitSubtopic, Unit
@@ -7,22 +9,26 @@ from courses.serializers import UnitSubtopicSerializer
 class SubtopicViewSet(viewsets.ModelViewSet):
     serializer_class = UnitSubtopicSerializer
     permission_classes = [IsAuthenticated]
+    lookup_field = "public_id"
+
+    def _get_unit_public_id(self):
+        return self.kwargs.get("unit_public_id") or self.kwargs.get("unit_pk")
 
     def get_queryset(self):
         queryset = UnitSubtopic.objects.all()
 
-        unit_pk = self.kwargs.get("unit_pk")
+        unit_public_id = self._get_unit_public_id()
 
-        if unit_pk:
-            queryset = queryset.filter(unit=unit_pk)
+        if unit_public_id:
+            queryset = queryset.filter(unit__public_id=unit_public_id)
 
         return queryset
 
     def perform_create(self, serializer):
-        unit_pk = self.kwargs.get("unit_pk")
+        unit_public_id = self._get_unit_public_id()
 
-        if unit_pk:
-            unit = Unit.objects.get(pk=unit_pk)
+        if unit_public_id:
+            unit = get_object_or_404(Unit, public_id=unit_public_id)
             serializer.save(unit=unit)
         else:
             serializer.save()

--- a/courses/views/unit_viewset.py
+++ b/courses/views/unit_viewset.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404
 class UnitViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]  # Add IsInstructor logic if needed
     serializer_class = UnitSerializer
+    lookup_field = "public_id"
 
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["course"]


### PR DESCRIPTION
- Add question option explanations and enrich question serializer metadata with public/unit identifiers
- Add question progress metrics (correct/total/completion) for courses and units
- Update related viewsets/serializers to use public IDs and add tests for metrics and option behavior